### PR TITLE
fix: check for empty map in the param before passing into Raw()

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -157,8 +157,14 @@ func (p *MySQL) GetRawCollection(query string, params ...map[string]any) ([]map[
 				query = strings.Split(query, " LIMIT ")[0] + " LIMIT 10"
 			}
 		}
-		if err := p.client.Raw(query, param).Find(&rows).Error; err != nil {
-			return nil, err
+		if len(param) > 0 {
+			if err := p.client.Raw(query, param).Find(&rows).Error; err != nil {
+				return nil, err
+			}
+		} else {
+			if err := p.client.Raw(query).Find(&rows).Error; err != nil {
+				return nil, err
+			}
 		}
 	} else if err := p.client.Raw(query).Find(&rows).Error; err != nil {
 		return nil, err
@@ -390,7 +396,6 @@ func (p *MySQL) FieldAsString(f Field, action string) string {
 		nullable = "NOT NULL"
 	}
 	if f.Default != nil {
-
 		switch def := f.Default.(type) {
 		case string:
 			if def == "CURRENT_TIMESTAMP" || strings.ToLower(def) == "true" || strings.ToLower(def) == "false" {

--- a/postgres.go
+++ b/postgres.go
@@ -234,8 +234,14 @@ func (p *Postgres) GetRawCollection(query string, params ...map[string]any) ([]m
 				query = strings.Split(query, " LIMIT ")[0] + " LIMIT 10"
 			}
 		}
-		if err := p.client.Raw(query, param).Find(&rows).Error; err != nil {
-			return nil, err
+		if len(param) > 0 {
+			if err := p.client.Raw(query, param).Find(&rows).Error; err != nil {
+				return nil, err
+			}
+		} else {
+			if err := p.client.Raw(query).Find(&rows).Error; err != nil {
+				return nil, err
+			}
 		}
 	} else if err := p.client.Raw(query).Find(&rows).Error; err != nil {
 		return nil, err


### PR DESCRIPTION
- passing empty map `map[]` in the `Raw()` function as `values` causes an error: `sql: converting argument $1 type: unsupported type map[string]interface {}, a map`